### PR TITLE
corrected pip install to use --upgrade

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ The latest stable version can always be installed or updated via pip:
 
 .. code-block:: bash
 
-    $ pip install --update holidays
+    $ pip install --upgrade holidays
 
 
 Documentation


### PR DESCRIPTION
The pip install command is using --update flag instead of --upgrade